### PR TITLE
Freshen 'now' line relative time and make whole line clickable

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -140,11 +140,15 @@ hr {
     margin-bottom: 1.4rem;
 }
 
+// Whole line is the clickable trigger; only the text carries the dotted rule.
 .now__trigger {
     color: $meta;
+    &:hover .now__text { border-bottom-color: $meta; }
+}
+
+.now__text {
     font-style: italic;
     border-bottom: 1px dotted $rule;
-    &:hover { border-bottom-color: $meta; }
 }
 
 .now__ago {

--- a/index.html
+++ b/index.html
@@ -20,8 +20,9 @@ title: Nalin
     {% assign then_s = now[0].date | date: '%s' %}
     {% assign days = now_s | minus: then_s | divided_by: 86400 %}
     <p class="now">
-      <a class="now__trigger" href="#now-history">{{ now[0].text }}</a>
-      <span class="now__ago">{% if days <= 0 %}today{% elsif days == 1 %}yesterday{% else %}{{ days }} days ago{% endif %}</span>
+      <a class="now__trigger" href="#now-history">
+        <span class="now__text">{{ now[0].text }}</span><span class="now__ago" data-date="{{ now[0].date | date: '%Y-%m-%d' }}">{% if days <= 0 %}today{% elsif days == 1 %}1d ago{% else %}{{ days }}d ago{% endif %}</span>
+      </a>
     </p>
     <div id="now-history" class="now-modal">
       <a class="now-modal__backdrop" href="#" aria-label="close"></a>
@@ -37,6 +38,22 @@ title: Nalin
         </ul>
       </div>
     </div>
+    <script>
+      // Keep the "ago" label fresh in the visitor's browser — the Liquid value
+      // above is frozen at build time, so it goes stale between deploys.
+      (function () {
+        var el = document.querySelector('.now__ago[data-date]');
+        if (!el) return;
+        var then = new Date(el.getAttribute('data-date') + 'T00:00:00');
+        var days = Math.floor((Date.now() - then.getTime()) / 86400000);
+        var label;
+        if (days <= 0) label = 'today';
+        else if (days < 30) label = days + 'd ago';
+        else if (days < 365) label = Math.floor(days / 30) + 'mo ago';
+        else label = Math.floor(days / 365) + 'y ago';
+        el.textContent = label;
+      })();
+    </script>
     {% endif %}
 
     <p class="sayhi">say hi — I like <a href="mailto:nalinbhardwaj@nibnalin.me">email from strangers</a>.</p>


### PR DESCRIPTION
The 'ago' label was computed in Liquid from site.time (build time), so it
froze to whenever the site was last built — showing 'today' for the Seoul
entry that was actually days old. Compute it client-side from a data-date
attribute so it stays fresh between deploys, with compact labels (Nd/Nmo/Ny
ago). The server-rendered value now uses the same compact format as a no-JS
fallback.

Also wrap the entire now line (text + ago) in the history-modal trigger anchor
so clicking anywhere on it opens the 'now — a history' dialog; the dotted
underline stays on the text only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PA8cvpzBHZ4e9xuY2fwwQV